### PR TITLE
Add postgres database container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [PR #1: Postgres database container](https://github.com/cyverse/atmosphere-docker/pull/1) - 2018-04-18
+## [PR #1: Postgres database container](https://github.com/cyverse/atmosphere-docker/pull/2) - 2018-04-18
 ---
 ### Added
 - Postgres container

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+## [PR #1: Postgres database container](https://github.com/cyverse/atmosphere-docker/pull/1) - 2018-04-18
+---
+### Added
+- Postgres container
+
+### Changed
+- Some build tasks in the Atmosphere and Troposphere containers required the database to be active, so I had to move these tasks into the entrypoint. This causes startup to take a little longer than before.
+- Using postgres container allows us to create Docker images for different Atmosphere versions **without** a database so that nothing is leaked, but then users can add a database file at startup, or use an existing database container.
+- Database dump documentation
+
+### Removed
+None.

--- a/README.md
+++ b/README.md
@@ -54,13 +54,9 @@ AUTH_ENABLE_MOCK: True
 AUTH_MOCK_USER: "calvinmclean"
 ```
 
-If you want to populate your database with production data, add these lines:
-```
-ATMO_DATA:
-  LOAD_DATABASE: True
-  SQL_DUMP_FILE: "{{ HOME }}/atmo_prod.sql"
-```
-And put the `SQL_DUMP_FILE` in `atmo-local` directory. **Make sure your containers are only locally accessible if you are doing this!!!**
+If you want to populate your database with production data, follow the directions in the `atmo-local` repository to download a sanitary sql dump and put it in `atmo-local` directory. **Make sure your containers are only locally accessible if you are doing this!!!**
+
+The database file will be picked up and used by the postgres container when you run `docker-compose up` after using `./setup.sh`
 
 
 ## Testing and development workflow
@@ -99,7 +95,8 @@ However, a simpler solution is to rebuild the Docker-Compose project using a dif
 docker-compose -p <other_name> build
 ```
 
-Another situation is that you want to rebuild from a different branch and you want to save the exact state of your existing container (such as the database), you can use `docker commit` to create an image from that container:
+Another situation is that you want to rebuild from a different branch and you want to save the exact state of your existing container you can use `docker commit` to create an image from that container:
+**Note: If you just want to preserve the state of your database, this is no longer necessary as long as you don't delete the postgres container.** Just delete the other containers and re-run `docker-compose up`.
 ```
 docker commit atmospheredocker_atmosphere_1 atmospheredocker_atmosphere:<tag>
 ```
@@ -114,9 +111,11 @@ This creates:
   - image: `alt_atmo`
   - image: `alt_tropo`
   - image: `alt_nginx`
+  - image: `alt_postgres`
   - container: `atmospheredocker_atmosphere-alt_1`
   - container: `atmospheredocker_troposphere-alt_1`
   - container: `atmospheredocker_nginx-alt_1`
+  - container: `atmospheredocker_postgres-alt_1`
   - volume: `alt_env`
   - volume: `alt_sockets`
   - volume: `alt_tropo`
@@ -126,11 +125,12 @@ Use `./alt-cleanup.sh` to remove these containers, images, and volumes.
 
 ## Containers/Services
 - [Atmosphere](https://github.com/cyverse/atmosphere)
-  - Entrypoint starts uWSGI, celeryd, redis-server, and postgresql
+  - Entrypoint starts uWSGI, celeryd, redis-server
 - [Troposphere](https://github.com/cyverse/troposphere)
-  - Entrypoint starts uWSGI, and postgresql
+  - Entrypoint starts uWSGI
 - [Guacamole & guacd](https://guacamole.apache.org/)
 - Nginx
+- [Postgres](https://hub.docker.com/_/postgres/)
 
 
 ## Guacamole
@@ -174,7 +174,7 @@ logs/
 
 `./cleanup.sh` -- deletes `atmo-local/` from each sub-directory (but not the main one at `atmosphere-docker/atmo-local/`) and clears the log directory
 
-Note: Use `./cleanup.sh --prune` to **ONLY** remove containers and volumes created by `docker-compose up`, without deleting other files
+Note: Use `./cleanup.sh --prune` to **ONLY** remove volumes created by `docker-compose up`, without deleting other files
 
 `docker-compose up` -- creates and starts the whole stack
 

--- a/alt-cleanup.sh
+++ b/alt-cleanup.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 echo "Killing and deleting alternate containers..."
-docker kill atmospheredocker_nginx-alt_1 atmospheredocker_troposphere-alt_1 atmospheredocker_atmosphere-alt_1
-docker rm atmospheredocker_nginx-alt_1 atmospheredocker_troposphere-alt_1 atmospheredocker_atmosphere-alt_1
+docker kill atmospheredocker_nginx-alt_1 atmospheredocker_troposphere-alt_1 atmospheredocker_atmosphere-alt_1 atmospheredocker_postgres-alt_1
+docker rm atmospheredocker_nginx-alt_1 atmospheredocker_troposphere-alt_1 atmospheredocker_atmosphere-alt_1 atmospheredocker_postgres-alt_1
 
 echo "Deleting alternate volumes..."
 docker volume rm alt_env alt_sockets alt_tropo
 
 echo "Deleting alternate images"
-docker rmi alt_atmo alt_tropo alt_nginx
+docker rmi alt_atmo alt_tropo alt_nginx alt_postgres

--- a/alt.sh
+++ b/alt.sh
@@ -4,6 +4,7 @@ echo "Committing containers to new images..."
 docker commit atmospheredocker_atmosphere_1 alt_atmo
 docker commit atmospheredocker_troposphere_1 alt_tropo
 docker commit atmospheredocker_nginx_1 alt_nginx
+docker commit atmospheredocker_postgres_1 alt_postgres
 
 echo "Stopping docker-compose..."
 docker-compose stop

--- a/atmosphere/Dockerfile
+++ b/atmosphere/Dockerfile
@@ -19,7 +19,8 @@ RUN apt-get install -y  \
     sudo
 
 # Prep Clank git repo and virtualenv; install pip requirements
-RUN pip install --upgrade pip virtualenv
+# RUN pip install --upgrade pip virtualenv
+RUN pip install --upgrade pip==9.0.3 virtualenv
 RUN mkdir -p $CLANK_WORKSPACE
 RUN mkdir -p /root/.ssh
 RUN git clone --depth 1 https://github.com/cyverse/clank.git $CLANK_WORKSPACE/clank;
@@ -56,17 +57,21 @@ ARG ATMO_BRANCH='master'
 ARG ANSIBLE_REPO='cyverse'
 ARG ANSIBLE_BRANCH='master'
 
-RUN service postgresql start &&                                   \
-    ansible-playbook playbooks/deploy_atmosphere.yml              \
+RUN ansible-playbook playbooks/deploy_atmosphere.yml              \
     -e @$CLANK_WORKSPACE/clank_init/build_env/variables.yml@local \
     -e atmosphere_ansible_github_repo=https://github.com/$ANSIBLE_REPO/atmosphere-ansible.git \
     -e atmosphere_github_repo=https://github.com/$ATMO_REPO/atmosphere.git \
     -e atmosphere_github_branch=$ATMO_BRANCH                      \
     -e atmosphere_ansible_github_branch=$ANSIBLE_BRANCH           \
-    --skip-tags=kernel,dependencies
+    --skip-tags=kernel,dependencies,database,manage-migrate,manage-load-tables
 
 RUN ansible-playbook playbooks/post_deployment.yml                \
     -e @$CLANK_WORKSPACE/clank_init/build_env/variables.yml@local
+
+RUN sed -i 's/^DATABASE_HOST = ""$/DATABASE_HOST = "postgres"/' ../../atmosphere/variables.ini
+RUN /opt/env/atmo/bin/python /opt/dev/atmosphere/configure
+
+ADD django_manage.yml $CLANK_WORKSPACE/clank/playbooks/django_manage.yml
 
 # Add entrypoint script
 ADD entrypoint.sh /root/entrypoint.sh

--- a/atmosphere/django_manage.yml
+++ b/atmosphere/django_manage.yml
@@ -1,0 +1,15 @@
+---
+- name: Migrate django stuff
+  hosts: atmosphere
+  roles:
+    - { role: app-django-manage-migrate,
+        APP_BASE_DIR: "{{ ATMOSPHERE_LOCATION | default(atmosphere_directory_path) }}",
+        VIRTUAL_ENV: "{{ VIRTUAL_ENV_ATMOSPHERE | default(atmosphere_virtualenv_path) }}",
+        DJANGO_SETTINGS_MODULE: 'atmosphere.settings',
+        tags: ['atmosphere', 'manage-migrate'] }
+
+    - { role: app-django-manage-load-tables,
+        APP_BASE_DIR: "{{ ATMOSPHERE_LOCATION | default(atmosphere_directory_path) }}",
+        VIRTUAL_ENV: "{{ VIRTUAL_ENV_ATMOSPHERE | default(atmosphere_virtualenv_path) }}",
+        DJANGO_SETTINGS_MODULE: 'atmosphere.settings',
+        tags: ['atmosphere','manage-load-tables'] }

--- a/atmosphere/entrypoint.sh
+++ b/atmosphere/entrypoint.sh
@@ -3,5 +3,10 @@
 service redis-server start
 service celerybeat start
 service celeryd start
-service postgresql start
+sleep 30
+source /opt/dev/clank_workspace/clank_env/bin/activate && cd /opt/dev/clank_workspace/clank && ansible-playbook playbooks/django_manage.yml -e @$CLANK_WORKSPACE/clank_init/build_env/variables.yml@local
+while [[ $? != 0 ]]; do
+  sleep 15
+  source /opt/dev/clank_workspace/clank_env/bin/activate && cd /opt/dev/clank_workspace/clank && ansible-playbook playbooks/django_manage.yml -e @$CLANK_WORKSPACE/clank_init/build_env/variables.yml@local
+done
 sudo su -l www-data -s /bin/bash -c "UWSGI_DEB_CONFNAMESPACE=app UWSGI_DEB_CONFNAME=atmosphere /opt/env/atmo/bin/uwsgi --ini /usr/share/uwsgi/conf/default.ini --ini /etc/uwsgi/apps-enabled/atmosphere.ini"

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -6,12 +6,6 @@ RM_CMD=`which rm`
 
 if [[ $1 == "--prune" ]]
 then
-  echo "Removing containers..."
-  docker container rm \
-  atmospheredocker_nginx_1 \
-  atmospheredocker_troposphere_1 \
-  atmospheredocker_atmosphere_1
-
   echo ""
   echo "Removing volumes..."
   docker volume rm \
@@ -23,6 +17,7 @@ else
   $RM_CMD -rf $PWD/nginx/atmo-local
   $RM_CMD -rf $PWD/atmosphere/atmo-local
   $RM_CMD -rf $PWD/troposphere/atmo-local
+  $RM_CMD -rf $PWD/postgres/atmo-local
 
   echo "Removing logs..."
   $RM_CMD -rf $PWD/logs/*

--- a/docker-compose-alt.yml
+++ b/docker-compose-alt.yml
@@ -3,6 +3,15 @@ version: '3'
 
 services:
 
+  postgres-alt:
+    image: postgres:9.6
+    environment:
+      POSTGRES_USER: 'atmo_app'
+      POSTGRES_PASSWORD: 'atmosphere'
+      POSTGRES_DB: 'atmo_prod'
+    volumes:
+      - './postgres/atmo-local:/docker-entrypoint-initdb.d'
+
   atmosphere-alt:
     image: 'alt_atmo'
     volumes:
@@ -10,6 +19,8 @@ services:
       - 'alt_sockets:/tmp:rw'
       - './logs/celery/atmo:/var/log/celery:rw'
       - './logs/atmosphere:/opt/dev/atmosphere/logs:rw'
+    depends_on:
+      - 'postgres-alt'
 
   troposphere-alt:
     image: 'alt_tropo'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,15 @@ version: '3'
 
 services:
 
+  postgres:
+    image: postgres:9.6
+    environment:
+      POSTGRES_USER: 'atmo_app'
+      POSTGRES_PASSWORD: 'atmosphere'
+      POSTGRES_DB: 'atmo_prod'
+    volumes:
+      - './postgres/atmo-local:/docker-entrypoint-initdb.d'
+
   atmosphere:
     build:
       context: './atmosphere'
@@ -16,6 +25,8 @@ services:
       - 'sockets:/tmp:rw'
       - './logs/celery/atmo:/var/log/celery:rw'
       - './logs/atmosphere:/opt/dev/atmosphere/logs:rw'
+    depends_on:
+      - 'postgres'
 
   troposphere:
     build:

--- a/postgres/readme.txt
+++ b/postgres/readme.txt
@@ -1,0 +1,1 @@
+This is a placeholder file to ensure that this directory is added to git.

--- a/setup.sh
+++ b/setup.sh
@@ -12,3 +12,6 @@ $CP_CMD -R $PWD/atmo-local $PWD/atmosphere/
 
 echo "Copying atmo-local to ./troposphere..."
 $CP_CMD -R $PWD/atmo-local $PWD/troposphere/
+
+echo "Copying atmo-local to ./postgres..."
+$CP_CMD -R $PWD/atmo-local $PWD/postgres/

--- a/troposphere/Dockerfile
+++ b/troposphere/Dockerfile
@@ -19,7 +19,8 @@ RUN apt-get install -y  \
     sudo
 
 # Prep Clank git repo and virtualenv; install pip requirements
-RUN pip install --upgrade pip virtualenv
+# RUN pip install --upgrade pip virtualenv
+RUN pip install --upgrade pip==9.0.3 virtualenv
 RUN mkdir -p $CLANK_WORKSPACE
 RUN mkdir -p /root/.ssh
 RUN git clone --depth 1 https://github.com/cyverse/clank.git $CLANK_WORKSPACE/clank;
@@ -54,15 +55,19 @@ RUN ansible-playbook playbooks/deploy_troposphere.yml             \
 ARG TROPO_REPO='cyverse'
 ARG TROPO_BRANCH='master'
 
-RUN service postgresql start &&                                   \
-    ansible-playbook playbooks/deploy_troposphere.yml             \
+RUN ansible-playbook playbooks/deploy_troposphere.yml             \
     -e @$CLANK_WORKSPACE/clank_init/build_env/variables.yml@local \
     -e troposphere_github_repo=https://github.com/$TROPO_REPO/troposphere.git \
     -e troposphere_github_branch=$TROPO_BRANCH                    \
-    --skip-tags=dependencies
+    --skip-tags=dependencies,database,manage-migrate
 
 RUN ansible-playbook playbooks/post_deployment.yml                \
     -e @$CLANK_WORKSPACE/clank_init/build_env/variables.yml@local
+
+RUN sed -i 's/^DATABASE_HOST = ""$/DATABASE_HOST = "postgres"/' /opt/dev/troposphere/variables.ini
+RUN /opt/env/troposphere/bin/python /opt/dev/troposphere/configure
+
+ADD django_manage.yml $CLANK_WORKSPACE/clank/playbooks/django_manage.yml
 
 # Add entrypoint script
 ADD entrypoint.sh /root/entrypoint.sh

--- a/troposphere/django_manage.yml
+++ b/troposphere/django_manage.yml
@@ -1,0 +1,22 @@
+---
+- name: Create troposphere database
+  hosts: troposphere
+  tasks:
+    - name: database {{ DBNAME | default("") }} is created
+      postgresql_db:
+        name: 'troposphere'
+        state: 'present'
+        login_user: 'atmo_app'
+        login_host: 'postgres'
+        login_password: 'atmosphere'
+      become: 'yes'
+      become_user: 'postgres'
+
+- name: Migrate django stuff
+  hosts: troposphere
+  roles:
+    - { role: app-django-manage-migrate,
+        APP_BASE_DIR: "{{ TROPOSPHERE_LOCATION | default(troposphere_directory_path) }}",
+        VIRTUAL_ENV: "{{ VIRTUAL_ENV_TROPOSPHERE | default(troposphere_virtualenv_path) }}",
+        DJANGO_SETTINGS_MODULE: 'troposphere.settings',
+        tags: ['troposphere', 'migrate', 'manage-migrate'] }

--- a/troposphere/entrypoint.sh
+++ b/troposphere/entrypoint.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
 
-service postgresql start
+sleep 30
+source /opt/dev/clank_workspace/clank_env/bin/activate && cd /opt/dev/clank_workspace/clank && ansible-playbook playbooks/django_manage.yml -e @$CLANK_WORKSPACE/clank_init/build_env/variables.yml@local
+while [[ $? != 0 ]]; do
+  sleep 15
+  source /opt/dev/clank_workspace/clank_env/bin/activate && cd /opt/dev/clank_workspace/clank && ansible-playbook playbooks/django_manage.yml -e @$CLANK_WORKSPACE/clank_init/build_env/variables.yml@local
+done
 sudo su -l www-data -s /bin/bash -c "UWSGI_DEB_CONFNAMESPACE=app UWSGI_DEB_CONFNAME=troposphere /opt/env/atmo/bin/uwsgi --ini /usr/share/uwsgi/conf/default.ini --ini /etc/uwsgi/apps-enabled/troposphere.ini"


### PR DESCRIPTION
This is a pretty complicated PR. It adds a postgres container, which required me to move some Clank tasks that are related to the DB to the entrypoints so that the database could be active. This slightly slows down startup on the first time, but once the database is imported it speeds up.

This PR enables a few nice features:
- We can publish container images with different Atmosphere/Troposphere versions since no database is included. Then, we can add the database when we consume the images. 
- We can easily switch to new Atmosphere/Troposphere containers without losing our current database. This negates the main purpose of the `alt` files, but I have not removed those yet.