### PR TITLE
Link Guacamole and Atmosphere for Web Shell access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ None.
 - All scripts that are no longer useful.
 - `alt` scripts may have been useful, but I think they were more confusing than they were worth.
 
+
 ---
 ## [PR #6: Use wait_for ansible module instead of sleep loop](https://github.com/cyverse/atmosphere-docker/pull/6) - 2018-05-10
 ### Added
@@ -69,6 +70,19 @@ None.
 
 ### Changed
 - Use ansible's `wait_for` module in the entrypoint playbooks instead of a sleep loop. This improved readability and startup time.
+
+### Removed
+None.
+
+
+---
+## [PR #7: Link Guacamole and Atmosphere for Web Shell access](https://github.com/cyverse/atmosphere-docker/pull/7) - 2018-05-16
+### Added
+- Named volume used by Guacamole and Atmosphere for storing SSH keys
+- Use local connection instead of SSH on role `sshkey-host-access`
+
+### Changed
+- Replaced all uses of `sed` in the setup playbooks with `lineinfile`
 
 ### Removed
 None.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ See atmo-local repository in GitLab for more information on setting up the atmo-
 
 
 ##### Required
-Set these variables in `atmo-local/clank_init/build_env/variables.yml@local`
+Set these variables in `atmo-local/clank_init/build_env/variables.yml@local`:
 ```
 SERVER_NAME: "localhost"
 HOME: /opt/dev/clank_workspace
@@ -71,6 +71,22 @@ GUACAMOLE_SERVER_URL: "http://guacamole:8080/guacamole"
 ```
 
 Change all occurrences of `/vagrant` to `{{ HOME }}`.
+
+Now for atmosphere-ansible requirements, change `atmo-local/clank_init/atmosphere-ansible/group_vars/all`:
+```
+GUACAMOLE_SERVER_IP: 0.0.0.0/0.0.0.0
+```
+
+This will allow VNC connections from anywhere, which is necessary since the Guacamole container will have unpredictable IP.
+
+Also change `atmo-local/clank_init/atmosphere-ansible/hosts`:
+```
+[gateone-hosts]
+guac_server ansible_host=guacamole
+localhost ansible_connection=local
+```
+
+This tells ansible to use the local connection instead of SSH when running on `localhost`, which is necessary for getting Guacamole SSH keys.
 
 
 ##### Optional

--- a/atmosphere/atmo_setup.yml
+++ b/atmosphere/atmo_setup.yml
@@ -31,10 +31,18 @@
   hosts: atmosphere
   tasks:
     - name: Make sure DATABASE_HOST is set to 'postgres'
-      shell: sed -i 's/^DATABASE_HOST = ""$/DATABASE_HOST = "postgres"/' /opt/dev/atmosphere/variables.ini
+      lineinfile:
+        state: present
+        path: '/opt/dev/atmosphere/variables.ini'
+        regexp: '^DATABASE_HOST = ""$'
+        line: 'DATABASE_HOST = "postgres"'
 
     - name: Make sure ADDITIONAL_ALLOWED_HOSTNAMES includes 'nginx'
-      shell: sed -i 's/^ADDITIONAL_ALLOWED_HOSTNAMES = \[\]$/ADDITIONAL_ALLOWED_HOSTNAMES = \["nginx"\]/' /opt/dev/atmosphere/variables.ini
+      lineinfile:
+        state: present
+        path: "/opt/dev/atmosphere/variables.ini"
+        regexp: '^ADDITIONAL_ALLOWED_HOSTNAMES = \[\]'
+        line: "ADDITIONAL_ALLOWED_HOSTNAMES = ['nginx']"
 
     - name: run generate script for app
       shell: '/opt/env/atmo/bin/python /opt/dev/atmosphere/configure'

--- a/atmosphere/web_shell_no_gateone.yml
+++ b/atmosphere/web_shell_no_gateone.yml
@@ -3,10 +3,10 @@
   hosts: atmosphere
   vars:
     EXTERNAL_HOST_KEY_DIR: "/etc/guacamole/keys/{{ ATMOUSERNAME }}"
-    EXTERNAL_HOST_KEY_OWNER: tomcat7
-    EXTERNAL_HOST_KEY_GROUP: tomcat7
+    EXTERNAL_HOST_KEY_OWNER: "root"
+    EXTERNAL_HOST_KEY_GROUP: "root"
     EXTERNAL_HOST_KEY_NAME: "id_rsa_guac"
-    EXTERNAL_HOST: "guac_server"
+    EXTERNAL_HOST: "localhost"
     USERNAME: "{{ ATMOUSERNAME }}"
   roles:
     - { role: "sshkey-host-access", when: (SETUP_GUACAMOLE | default(false)) == true }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     volumes:
       - 'atmo-env:/opt/env/atmo:rw'
       - 'sockets:/tmp:rw'
+      - 'guacamole-keys:/etc/guacamole/keys:rw'
       - './logs/celery/atmo:/var/log/celery:rw'
       - './logs/atmosphere:/opt/dev/atmosphere/logs:rw'
       - './atmo-local/clank_init:/opt/dev/clank_workspace/clank_init:ro'
@@ -68,6 +69,7 @@ services:
       GUACD_HOSTNAME: 'guacd'
     volumes:
       - './guacamole:/guac_stuff:rw'
+      - 'guacamole-keys:/guac_stuff/keys:rw'
     ports:
       - '8080:8080'
 
@@ -78,3 +80,4 @@ volumes:
   atmo-env:
   sockets:
   tropo:
+  guacamole-keys:

--- a/troposphere/tropo_setup.yml
+++ b/troposphere/tropo_setup.yml
@@ -12,16 +12,32 @@
   hosts: troposphere
   tasks:
     - name: Make sure DATABASE_HOST is set to 'postgres'
-      shell: sed -i 's/^DATABASE_HOST = ""$/DATABASE_HOST = "postgres"/' /opt/dev/troposphere/variables.ini
+      lineinfile:
+        state: present
+        path: '/opt/dev/troposphere/variables.ini'
+        regexp: '^DATABASE_HOST = ""$'
+        line: 'DATABASE_HOST = "postgres"'
 
     - name: Make sure ADDITIONAL_ALLOWED_HOSTNAMES has 'nginx'
-      shell: sed -i 's/^ADDITIONAL_ALLOWED_HOSTNAMES = \[\]$/ADDITIONAL_ALLOWED_HOSTNAMES = \["nginx"\]/' /opt/dev/troposphere/variables.ini
+      lineinfile:
+        state: present
+        path: "/opt/dev/troposphere/variables.ini"
+        regexp: '^ADDITIONAL_ALLOWED_HOSTNAMES = \[\]'
+        line: "ADDITIONAL_ALLOWED_HOSTNAMES = ['nginx']"
 
     - name: Make sure API_SERVER is set to 'nginx' by hard-coding web_desktop.py
-      shell: sed -i 's/^            api_root=settings.API_V2_ROOT,$/            api_root="https\:\/\/nginx\/api\/v2",/' /opt/dev/troposphere/troposphere/views/web_desktop.py
+      lineinfile:
+        state: present
+        path: "/opt/dev/troposphere/troposphere/views/web_desktop.py"
+        regexp: '^            api_root=settings.API_V2_ROOT,$'
+        line: "            api_root='https://nginx/api/v2',"
 
     - name: Fix Guacamole URL with hard-coding
-      shell: sed -i 's/^    url = data.get('token_url')$/    url = data.get('token_url').replace("guacamole","localhost",1)/' /opt/dev/troposphere/troposphere/views/web_desktop.py
+      lineinfile:
+        state: present
+        path: "/opt/dev/troposphere/troposphere/views/web_desktop.py"
+        regexp: "^    url = .+$"
+        line: "    url = data.get('token_url').replace('guacamole','localhost',1)"
 
     - name: run generate script for app
       shell: '/opt/env/troposphere/bin/python /opt/dev/troposphere/configure'


### PR DESCRIPTION
Use a named volume to link the Guacamole containers key directory to the atmosphere container so SSH doesn't have to be used for the role. A few other changes to the setup ansible so now Guacamole works flawlessly