### PR TITLE
Problem: Undefined variable breaks Nginx

### DIFF
--- a/nginx/configure_nginx.yml
+++ b/nginx/configure_nginx.yml
@@ -5,7 +5,7 @@
         TLS_CREATE_SELFSIGNED: false,
         TLS_COMMON_NAME: 'localhost' }
     - { role: configure-nginx,
-        SERVER_URL: "{{ nginx_server_url }}",
+        SERVER_URL: "https://{{ server_name }}",
         SITE_SERVER_NAME: "{{ server_name }}",
         LOCATIONS: "{{ nginx_locations }}",
         SSL_KEY: "{{ TLS_PRIVKEY_PATH }}",


### PR DESCRIPTION
```
nginx_1        | TASK [configure-nginx : Template nginx site: /etc/nginx/sites-available/site.conf] ***
nginx_1        | Wednesday 05 September 2018  00:15:53 +0000 (0:00:12.560)       0:00:20.062 ***
nginx_1        | fatal: [localhost]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: {{ nginx_server_url }}: 'nginx_server_url' is undefined"}
nginx_1        |
nginx_1        | msg: AnsibleUndefinedVariable: {{ nginx_server_url }}: 'nginx_server_url' is undefined
```

Due to this PR: https://github.com/cyverse/clank/pull/267

Solution: Use `server_name` instead of `nginx_server_url`