### PR TITLE
Add volumes to enable Chromogenic/virt-sysprep on Atmosphere

### DIFF
--- a/docker-compose.atmo-test.yml
+++ b/docker-compose.atmo-test.yml
@@ -10,7 +10,7 @@ services:
       POSTGRES_PASSWORD: 'atmosphere_db_pass'
 
   atmosphere:
-    image: 'calvinmclean/atmosphere:latest'
+    image: 'cyverse/atmosphere:latest'
     entrypoint: '/root/test.sh'
     depends_on:
       - 'postgres'

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -13,12 +13,12 @@ services:
       TROPO_DB_NAME: 'troposphere'
 
   atmosphere:
-    image: 'calvinmclean/atmosphere:latest'
+    image: 'cyverse/atmosphere:latest'
     depends_on:
       - 'postgres'
 
   troposphere:
-    image: 'calvinmclean/troposphere:latest'
+    image: 'cyverse/troposphere:latest'
     depends_on:
       - 'atmosphere'
     ports:

--- a/docker-compose.tropo-test.yml
+++ b/docker-compose.tropo-test.yml
@@ -11,7 +11,7 @@ services:
       POSTGRES_DB: 'troposphere_db'
 
   troposphere:
-    image: 'calvinmclean/troposphere:latest'
+    image: 'cyverse/troposphere:latest'
     entrypoint: '/root/test.sh'
     depends_on:
       - 'postgres'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       - '../atmosphere:/opt/dev/atmosphere'
       - '../atmosphere-ansible:/opt/dev/atmosphere-ansible'
       - '../atmosphere-docker-secrets:/opt/dev/atmosphere-docker-secrets'
+      - '/boot:/boot'
+      - '/lib/modules:/lib/modules'
     depends_on:
       - 'postgres'
 


### PR DESCRIPTION
## Description

In order to use `virt-sysprep` for imaging, a few system directories must be accessible from inside the Docker container. 