### PR TITLE
Allow populating Troposphere database from dump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 atmo-local/
 logs/
 *.sql
+*.dump
 secrets.env

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Entire Atmosphere development environment in Docker Containers using Docker-Comp
 
 
 2. `docker-compose pull` to pull all containers
-    - To populate with an existing database, copy the `.sql` file to the `postgres` directory before building
+    - To populate with an existing Atmosphere database, copy the `*.sql` file to the `postgres` directory
+    - To populate with a Troposphere database, copy the `tropo*.sql.dump` file to the `postgres` directory. If the file is a `*.sql` file, the postgres image will attempt to dump it into the Atmosphere database instead of the Troposphere database
 
 
 3. Clone the `atmosphere-docker-secrets` repository in the same directory as this repository (not inside this repository directory)

--- a/postgres/create_tropo_db.sh
+++ b/postgres/create_tropo_db.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 set -e
 
-POSTGRES="psql --username ${POSTGRES_USER} ${POSTGRES_DB}"
+POSTGRES="psql --username ${POSTGRES_USER}"
 
 echo "Creating database: ${TROPO_DB_NAME}"
 
-$POSTGRES <<EOSQL
+$POSTGRES ${POSTGRES_DB} <<EOSQL
 CREATE DATABASE ${TROPO_DB_NAME} OWNER ${POSTGRES_USER};
 EOSQL
+
+if [ -e /docker-entrypoint-initdb.d/tropo*.sql.dump ]; then
+  echo "Loading Troposphere database dump"
+  $POSTGRES ${TROPO_DB_NAME} -f /docker-entrypoint-initdb.d/tropo*.sql.dump
+fi


### PR DESCRIPTION
These changes will allow populating the Troposphere database from a dump file. The file must be named `tropo*.sql.dump` because if it is `*.sql`, the postgres image will attempt to dump it into the Atmosphere database which will cause errors. This is optional.