### PR TITLE
Add sanitarysql container

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -31,3 +31,13 @@ services:
     ports:
       - '443:443'
       - '80:80'
+
+  sanitarysql:
+    build: './sanitarysql'
+    volumes:
+      - '../atmosphere-docker-secrets/ssh:/root/.ssh'
+      - './sanitarysql/data:/root/data'
+    ports:
+      - '1234:22'
+    env_file:
+      - '../atmosphere-docker-secrets/env'

--- a/sanitarysql/Dockerfile
+++ b/sanitarysql/Dockerfile
@@ -1,0 +1,29 @@
+FROM alpine:latest
+
+RUN apk update && \
+    apk add openssh postgresql
+RUN echo -e 'PermitRootLogin no\n\
+AllowGroups users root\n\
+PrintMotd no' >> /etc/ssh/sshd_config
+RUN ssh-keygen -A
+
+COPY crontab /etc/crontabs/sanitarysql
+
+# Create user and unlock password-less account
+RUN adduser -D -s '/home/sanitarysql/cat-sql-dump.sh' -G users sanitarysql &&\
+    sed -i s/sanitarysql:!/"sanitarysql:*"/g /etc/shadow
+
+COPY *.sh /home/sanitarysql/
+
+RUN chmod +x /home/sanitarysql/*.sh &&\
+    mkdir /home/sanitarysql/.ssh &&\
+    chown -R sanitarysql /home/sanitarysql &&\
+    echo "no sanitized dumps present yet" > /tmp/atmo_prod-sanitized.sql
+
+EXPOSE 22
+CMD sed -i "s/NFS_PORT/${NFS_PORT}/" /etc/crontabs/sanitarysql &&\
+    sed -i "s/NFS_HOST/${NFS_HOST}/" /etc/crontabs/sanitarysql &&\
+    crontab /etc/crontabs/sanitarysql &&\
+    cp /root/.ssh/authorized_keys /home/sanitarysql/.ssh/authorized_keys &&\
+    /home/sanitarysql/sanitize-dump.sh &&\
+    /usr/sbin/sshd -D

--- a/sanitarysql/cat-sql-dump.sh
+++ b/sanitarysql/cat-sql-dump.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/bin/cat /tmp/atmo_prod-sanitized.sql

--- a/sanitarysql/crontab
+++ b/sanitarysql/crontab
@@ -1,0 +1,7 @@
+# m h  dom mon dow   command
+0 1 * * * PGPASSWORD=atmosphere pg_dump -h postgres -p 5432 -U atmo_app atmo_prod > "/root/data/atmo-$(date +\%F).sql"
+0 1 * * * PGPASSWORD=atmosphere pg_dump -h postgres -p 5432 -U atmo_app troposphere > "/root/data/tropo-$(date +\%F).sql"
+0 2 * * * scp -P NFS_PORT /root/data/atmo-$(date +\%F).sql root@NFS_HOST:/nfs_exports/db_backups/atmo/ &> /dev/null
+0 2 * * * scp -P NFS_PORT /root/data/tropo-$(date +\%F).sql root@NFS_HOST:/nfs_exports/db_backups/atmo/ &> /dev/null
+30 2 * * * d=$(date +\%F -d "now -10 days"); rm -f /root/data/atmo-${d}.sql /root/data/tropo-${d}.sql
+@daily /home/sanitarysql/sanitize-dump.sh &> /dev/null

--- a/sanitarysql/sanitize-dump.sh
+++ b/sanitarysql/sanitize-dump.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+# Exit if any command fails
+set -e;
+
+db_info='-h postgres -p 5432 -U atmo_app'
+export PGPASSWORD='atmosphere'
+
+# Create temporary database used to create database dump
+createdb $db_info tmp_sanitary_db;
+
+# If we exit for any reason (including end of this script), remove the temporary database
+trap "dropdb ${db_info} tmp_sanitary_db" EXIT;
+
+# Dump production database and load into temporary database
+pg_dump $db_info atmo_prod | psql $db_info tmp_sanitary_db;
+
+# Sanitize db
+psql $db_info tmp_sanitary_db <<'EOF'
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+UPDATE atmosphere_user SET password = 'PASSWORD_REDACTED';
+UPDATE ssh_key SET pub_key = 'PUB_KEY_REDACTED';
+UPDATE boot_script SET title = 'title_REDACTED', script_text = 'script_text_REDACTED';
+UPDATE credential SET key = 'key_REDACTED', value = 'value_REDACTED';
+UPDATE django_admin_log SET change_message = 'change_message_REDACTED', object_repr = 'object_repr_REDACTED';
+UPDATE django_cyverse_auth_accesstoken SET key = 'KEY_REDACTED';
+-- This one tends to have millions of rows so we drop the secret column rather than overwriting it
+ALTER TABLE django_cyverse_auth_token DROP COLUMN key CASCADE;
+UPDATE django_cyverse_auth_userproxy SET "proxyIOU" = 'proxyIOU_REDACTED', "proxyTicket" = 'proxyTicket_REDACTED';
+UPDATE django_session SET session_key = 'RDD_' || uuid_generate_v4(), session_data = 'session_data_REDACTED';
+UPDATE external_link SET title = 'title_REDACTED', link = 'link_REDACTED', description = 'description_REDACTED';
+UPDATE iplantauth_accesstoken SET key = 'KEY_REDACTED';
+UPDATE iplantauth_token SET key = 'KEY_REDACTED_' || uuid_generate_v4();
+UPDATE iplantauth_userproxy SET "proxyIOU" = 'proxyIOU_REDACTED', "proxyTicket" = 'proxyTicket_REDACTED';
+UPDATE node_controller SET private_ssh_key = 'private_ssh_key_REDACTED';
+UPDATE provider SET cloud_config = NULL;
+UPDATE provider_credential SET key = 'key_REDACTED', value = 'value_REDACTED';
+EOF
+
+# These commands may fail (tables may not exist on all deployments), so always exit 0 and suppress stderr
+QUERYMAYFAIL=`cat << EOF
+UPDATE access_token SET key = 'KEY_REDACTED';
+UPDATE auth_token SET key = 'KEY_REDACTED_' || uuid_generate_v4();
+UPDATE auth_userproxy SET "proxyIOU" = 'proxyIOU_REDACTED', "proxyTicket" = 'proxyTicket_REDACTED';
+EOF
+`
+# psql $db_info tmp_sanitary_db "$QUERYMAYFAIL" 2>/dev/null | true
+echo $QUERYMAYFAIL | psql $db_info tmp_sanitary_db || true
+
+# Create sanitary dump
+pg_dump $db_info tmp_sanitary_db > /tmp/atmo_prod-sanitized.sql;


### PR DESCRIPTION
## Description

This PR adds a new service that is a simple Alpine linux container running an SSH server. It has cronjobs to connect to the postgres container periodically to create database backups as well as sanitary database dumps. The backups are copied to an NFS server and the sanitary dumps are accessible by SSH