### PR TITLE
Allow prod setup to connect to databse on docker host

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Entire Atmosphere development environment in Docker Containers using Docker-Comp
     - Alternatively, modify the docker-compose file to point to your local repositories with either relative or absolute paths
 
 
-2. `docker-compose pull` to pull all containers
+2. `atmosphere-docker.sh pull` to pull all containers
     - To populate with an existing Atmosphere database, copy the `*.sql` file to the `postgres` directory
     - To populate with a Troposphere database, copy the `tropo*.sql.dump` file to the `postgres` directory. If the file is a `*.sql` file, the postgres image will attempt to dump it into the Atmosphere database instead of the Troposphere database
 
@@ -17,9 +17,9 @@ Entire Atmosphere development environment in Docker Containers using Docker-Comp
     - Use the script `mock_user.sh <your_cyverse_username>` to change `MOCK_USER` variable in `atmosphere.ini` and `troposphere.ini` to your username if using 'local' variables branch
 
 
-4. `docker-compose up` to start all containers (use the `-d` option to run containers in the background)
+4. `atmosphere-docker.sh up` to start all containers (use the `-d` option to run containers in the background)
     - The container's entrypoint will automatically read a variable from the `env` file in `atmosphere-docker-secrets` to determine if running a production or development environment
-    - If you are using a local development version and want Guacamole also, replace the `docker-compose` part of all commands with: `docker-compose -f docker-compose.yml -f docker-compose.guac.yml`
+    - If you are using a local development version and want Guacamole also, replace the `atmosphere-docker.sh` part of all commands with: `atmosphere-docker.sh -f docker-compose.yml -f docker-compose.guac.yml`
     - If using local development version:
       - **IMPORTANT**: If you are using Linux and want to maintain ownership of your local repositories, edit the `command` lines in `docker-compose.yml` with your user id (use `id -u` to get this). User ID `1000` is the default
       - Your containers should be ready when you see `webpack: Compiled successfully.` from Troposphere and `Starting Django Python...` from Atmosphere
@@ -49,9 +49,9 @@ docker exec -ti $(docker ps -f name=atmosphere_ --format "{{.Names}}") /opt/env/
 ### Tips
 Gracefully shut down containers with `Ctrl+c`. Press it again to kill containers.
 
-Or kill all containers with `docker-compose kill`.
+Or kill all containers with `atmosphere-docker.sh kill`.
 
-Delete all containers when you are done with `docker-compose rm`.
+Delete all containers when you are done with `atmosphere-docker.sh rm`.
 
 Delete all unattached volumes with `docker volume prune`.
 

--- a/atmosphere-docker.sh
+++ b/atmosphere-docker.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+dockerhost=$(ip addr show docker0 | grep -Po 'inet \K[\d.]+') docker-compose $1

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,7 +10,7 @@ services:
       - '/boot:/boot'
       - '/lib/modules:/lib/modules'
     extra_hosts:
-      - 'postgres:172.17.0.1'
+      - 'postgres:${dockerhost}'
 
   troposphere:
     image: 'cyverse/troposphere:latest'
@@ -22,4 +22,4 @@ services:
       - '443:443'
       - '80:80'
     extra_hosts:
-      - 'postgres:172.17.0.1'
+      - 'postgres:${dockerhost}'

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,7 +9,8 @@ services:
       - '../atmosphere-docker-secrets:/opt/dev/atmosphere-docker-secrets'
       - '/boot:/boot'
       - '/lib/modules:/lib/modules'
-    network_mode: 'host'
+    extra_hosts:
+      - 'postgres:172.17.0.1'
 
   troposphere:
     image: 'cyverse/troposphere:latest'
@@ -20,4 +21,5 @@ services:
     ports:
       - '443:443'
       - '80:80'
-    network_mode: 'host'
+    extra_hosts:
+      - 'postgres:172.17.0.1'

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,24 +3,13 @@ version: '3'
 
 services:
 
-  postgres:
-    image: 'postgres:9.6'
-    volumes:
-      - './postgres:/docker-entrypoint-initdb.d'
-    environment:
-      POSTGRES_USER: 'atmo_app'
-      POSTGRES_PASSWORD: 'atmosphere'
-      POSTGRES_DB: 'atmo_prod'
-      TROPO_DB_NAME: 'troposphere'
-
   atmosphere:
     image: 'cyverse/atmosphere:latest'
     volumes:
       - '../atmosphere-docker-secrets:/opt/dev/atmosphere-docker-secrets'
       - '/boot:/boot'
       - '/lib/modules:/lib/modules'
-    depends_on:
-      - 'postgres'
+    network_mode: 'host'
 
   troposphere:
     image: 'cyverse/troposphere:latest'
@@ -31,3 +20,4 @@ services:
     ports:
       - '443:443'
       - '80:80'
+    network_mode: 'host'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       POSTGRES_PASSWORD: 'atmosphere'
       POSTGRES_DB: 'atmo_prod'
       TROPO_DB_NAME: 'troposphere'
+    network_mode: 'host'
 
   atmosphere:
     image: 'cyverse/atmosphere:latest'
@@ -24,6 +25,7 @@ services:
       - '/lib/modules:/lib/modules'
     depends_on:
       - 'postgres'
+    network_mode: 'host'
 
   troposphere:
     image: 'cyverse/troposphere:latest'
@@ -36,3 +38,4 @@ services:
     ports:
       - '443:443'
       - '80:80'
+    network_mode: 'host'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       POSTGRES_PASSWORD: 'atmosphere'
       POSTGRES_DB: 'atmo_prod'
       TROPO_DB_NAME: 'troposphere'
+    ports:
+      - '5432:5432'
     network_mode: 'host'
 
   atmosphere:
@@ -25,7 +27,9 @@ services:
       - '/lib/modules:/lib/modules'
     depends_on:
       - 'postgres'
-    network_mode: 'host'
+    extra_hosts:
+      - 'postgres:172.17.0.1'
+
 
   troposphere:
     image: 'cyverse/troposphere:latest'
@@ -38,4 +42,5 @@ services:
     ports:
       - '443:443'
       - '80:80'
-    network_mode: 'host'
+    extra_hosts:
+      - 'postgres:172.17.0.1'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     depends_on:
       - 'postgres'
     extra_hosts:
-      - 'postgres:172.17.0.1'
+      - 'postgres:${dockerhost}'
 
 
   troposphere:
@@ -43,4 +43,4 @@ services:
       - '443:443'
       - '80:80'
     extra_hosts:
-      - 'postgres:172.17.0.1'
+      - 'postgres:${dockerhost}'


### PR DESCRIPTION
## Description

This PR allows atmosphere-docker to run on localhost and connect to a database outside of the docker environment/network in production setups

The development setup will still use a containerized database but also runs on localhost