### PR TITLE
Mount log directories on a volume

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,6 +7,8 @@ services:
     image: 'cyverse/atmosphere:v36-4'
     volumes:
       - '../atmosphere-docker-secrets:/opt/dev/atmosphere-docker-secrets'
+      - './logs/atmosphere:/opt/dev/atmosphere/logs'
+      - './logs/celery:/var/log/celery'
       - '/boot:/boot'
       - '/lib/modules:/lib/modules'
     extra_hosts:
@@ -16,6 +18,7 @@ services:
     image: 'cyverse/troposphere:v36-4'
     volumes:
       - '../atmosphere-docker-secrets:/opt/dev/atmosphere-docker-secrets'
+      - './logs/troposphere:/opt/dev/troposphere/logs'
     depends_on:
       - 'atmosphere'
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       - '../atmosphere:/opt/dev/atmosphere'
       - '../atmosphere-ansible:/opt/dev/atmosphere-ansible'
       - '../atmosphere-docker-secrets:/opt/dev/atmosphere-docker-secrets'
+      - './logs/atmosphere:/opt/dev/atmosphere/logs'
+      - './logs/celery:/var/log/celery'
       - '/boot:/boot'
       - '/lib/modules:/lib/modules'
     depends_on:
@@ -37,6 +39,7 @@ services:
     volumes:
       - '../troposphere:/opt/dev/troposphere'
       - '../atmosphere-docker-secrets:/opt/dev/atmosphere-docker-secrets'
+      - './logs/troposphere:/opt/dev/troposphere/logs'
     depends_on:
       - 'atmosphere'
     ports:


### PR DESCRIPTION
## Description

This is a simple change that will mount the Troposphere, Atmosphere, and Celery logging directories into `./logs`