### PR TITLE
Use 'network_mode: host' for all services

### DIFF
--- a/atmosphere-docker.sh
+++ b/atmosphere-docker.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-dockerhost=$(ip addr show docker0 | grep -Po 'inet \K[\d.]+') docker-compose $@
+docker-compose $@

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,7 +4,7 @@ version: '3'
 services:
 
   atmosphere:
-    image: 'cyverse/atmosphere:release-v36-7'
+    image: 'cyverse/atmosphere:release-v36-9'
     volumes:
       - '../atmosphere-docker-secrets:/opt/dev/atmosphere-docker-secrets'
       - './logs/atmosphere:/opt/dev/atmosphere/logs'

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,7 +12,10 @@ services:
       - '/boot:/boot'
       - '/lib/modules:/lib/modules'
     extra_hosts:
-      - 'postgres:${dockerhost}'
+      - 'atmosphere:127.0.0.1'
+      - 'postgres:127.0.0.1'
+    network_mode: 'host'
+
 
   troposphere:
     image: 'cyverse/troposphere:release-v36-6'
@@ -21,8 +24,7 @@ services:
       - './logs/troposphere:/opt/dev/troposphere/logs'
     depends_on:
       - 'atmosphere'
-    ports:
-      - '443:443'
-      - '80:80'
     extra_hosts:
-      - 'postgres:${dockerhost}'
+      - 'atmosphere:127.0.0.1'
+      - 'postgres:127.0.0.1'
+    network_mode: 'host'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,9 @@ services:
     depends_on:
       - 'postgres'
     extra_hosts:
-      - 'postgres:${dockerhost}'
-
+      - 'atmosphere:127.0.0.1'
+      - 'postgres:127.0.0.1'
+    network_mode: 'host'
 
   troposphere:
     image: 'cyverse/troposphere:latest'
@@ -42,8 +43,7 @@ services:
       - './logs/troposphere:/opt/dev/troposphere/logs'
     depends_on:
       - 'atmosphere'
-    ports:
-      - '443:443'
-      - '80:80'
     extra_hosts:
-      - 'postgres:${dockerhost}'
+      - 'atmosphere:127.0.0.1'
+      - 'postgres:127.0.0.1'
+    network_mode: 'host'


### PR DESCRIPTION
This required using 'extra_hosts' to map other services hostnames to `127.0.0.1`. Since `dockerhost` variable is no longer needed, I removed it from the 'atmosphere-docker.sh' script, but kept the script for backwards compatibility